### PR TITLE
Ajout édition des saisies, validation km par date et affichage prix sans km

### DIFF
--- a/app/api/entries/route.ts
+++ b/app/api/entries/route.ts
@@ -68,6 +68,48 @@ export async function POST(request: NextRequest) {
   }
 }
 
+// PUT - Modifier une entrée existante
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { id, date, kmCompteur, litres, prixLitre, isFullTank } = body
+
+    // Validation
+    if (id === undefined || !date || kmCompteur === undefined || litres === undefined || prixLitre === undefined) {
+      return NextResponse.json(
+        { error: 'Tous les champs sont requis' },
+        { status: 400 }
+      )
+    }
+
+    const entry = await prisma.fuelEntry.update({
+      where: { id: parseInt(id) },
+      data: {
+        date: new Date(date),
+        kmCompteur: parseFloat(kmCompteur),
+        litres: parseFloat(litres),
+        prixLitre: parseFloat(prixLitre),
+        isFullTank: isFullTank !== undefined ? isFullTank : true,
+      },
+    })
+
+    return NextResponse.json({
+      id: entry.id,
+      date: entry.date.toISOString().split('T')[0],
+      kmCompteur: entry.kmCompteur,
+      litres: entry.litres,
+      prixLitre: entry.prixLitre,
+      isFullTank: entry.isFullTank,
+    })
+  } catch (error) {
+    console.error('Erreur PUT /api/entries:', error)
+    return NextResponse.json(
+      { error: 'Erreur lors de la modification de l\'entrée' },
+      { status: 500 }
+    )
+  }
+}
+
 // DELETE - Supprimer une entrée
 export async function DELETE(request: NextRequest) {
   try {

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,14 @@
            disabled:opacity-50 disabled:cursor-not-allowed;
   }
   
+  .btn-secondary {
+    @apply bg-gray-700 text-gray-200 px-6 py-3 rounded-lg font-semibold
+           hover:bg-gray-600 active:bg-gray-700 border border-gray-600
+           transition-all duration-200
+           focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-gray-900
+           disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
   .btn-danger {
     @apply text-red-400 hover:text-red-300 hover:bg-red-900/20 
            p-2 rounded-lg transition-all duration-200

--- a/components/FuelConsumptionApp.tsx
+++ b/components/FuelConsumptionApp.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import { AlertCircle, Fuel, Loader2, Trash2 } from 'lucide-react'
 import { FuelEntry, NewEntryForm } from '@/lib/types'
-import { calculateStats, estimateTrip, estimateFullTankCost, DEFAULT_TANK_CAPACITY } from '@/lib/calculations'
+import { calculateStats, estimateTrip, estimateFullTankCost, validateKmCompteur, DEFAULT_TANK_CAPACITY } from '@/lib/calculations'
 import { Header } from '@/components/ui/Header'
 import { NavigationTabs } from '@/components/ui/NavigationTabs'
 import { DashboardTab } from '@/components/fuel/DashboardTab'
@@ -27,6 +27,8 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
   const [loginError, setLoginError] = useState<string | null>(null)
   const [loginLoading, setLoginLoading] = useState(false)
   const [kmCompteurError, setKmCompteurError] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [successSignal, setSuccessSignal] = useState(0)
 
   const [newEntry, setNewEntry] = useState<NewEntryForm>({
     date: new Date().toISOString().split('T')[0],
@@ -76,6 +78,19 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
     }
   }, [])
 
+  const resetForm = useCallback(() => {
+    setNewEntry({
+      date: new Date().toISOString().split('T')[0],
+      kmCompteur: '',
+      litres: '',
+      prixLitre: '',
+      isFullTank: true,
+    })
+    setEditingId(null)
+    setKmCompteurError(null)
+    setError(null)
+  }, [])
+
   const addEntry = useCallback(async () => {
     if (!newEntry.litres || !newEntry.prixLitre) {
       setError('Veuillez remplir tous les champs requis')
@@ -85,16 +100,18 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
     // Déterminer automatiquement le mode selon si kmCompteur est rempli
     const hasKilometers = newEntry.kmCompteur && newEntry.kmCompteur.trim() !== ''
 
-    // Validation : vérifier que le km compteur est supérieur au dernier enregistré (seulement si rempli)
+    // Validation : le kilométrage doit être cohérent avec la date de la saisie
+    // (supérieur aux relevés antérieurs, inférieur aux relevés postérieurs)
     if (hasKilometers) {
-      const entriesWithKm = entries.filter(entry => entry.kmCompteur > 0)
-      const lastKmCompteur = entriesWithKm.length > 0
-        ? Math.max(...entriesWithKm.map(entry => entry.kmCompteur))
-        : 0
-
       const currentKmCompteur = parseFloat(newEntry.kmCompteur)
-      if (currentKmCompteur <= lastKmCompteur) {
-        setKmCompteurError(`Le kilométrage doit être supérieur au dernier relevé (${lastKmCompteur.toLocaleString('fr-FR')} km)`)
+      const kmError = validateKmCompteur(
+        entries,
+        newEntry.date,
+        currentKmCompteur,
+        editingId ?? undefined
+      )
+      if (kmError) {
+        setKmCompteurError(kmError)
         return
       }
     }
@@ -103,37 +120,74 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
     setError(null)
     setKmCompteurError(null)
 
+    const payload = {
+      date: newEntry.date,
+      kmCompteur: hasKilometers ? parseFloat(newEntry.kmCompteur) : 0,
+      litres: parseFloat(newEntry.litres),
+      prixLitre: parseFloat(newEntry.prixLitre),
+      isFullTank: newEntry.isFullTank,
+    }
+
     try {
-      const response = await fetch('/api/entries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          date: newEntry.date,
-          kmCompteur: hasKilometers ? parseFloat(newEntry.kmCompteur) : 0,
-          litres: parseFloat(newEntry.litres),
-          prixLitre: parseFloat(newEntry.prixLitre),
-          isFullTank: newEntry.isFullTank,
-        }),
-      })
+      if (editingId !== null) {
+        const response = await fetch('/api/entries', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: editingId, ...payload }),
+        })
 
-      if (!response.ok) throw new Error('Erreur lors de l\'ajout')
+        if (!response.ok) throw new Error('Erreur lors de la modification')
 
-      const entry = await response.json()
-      setEntries((prev) => [...prev, entry])
-      setNewEntry({
-        date: new Date().toISOString().split('T')[0],
-        kmCompteur: '',
-        litres: '',
-        prixLitre: '',
-        isFullTank: true,
-      })
+        const updated = await response.json()
+        setEntries((prev) => prev.map((e) => (e.id === updated.id ? updated : e)))
+        resetForm()
+        setSuccessSignal((s) => s + 1)
+      } else {
+        const response = await fetch('/api/entries', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+
+        if (!response.ok) throw new Error('Erreur lors de l\'ajout')
+
+        const entry = await response.json()
+        setEntries((prev) => [...prev, entry])
+        resetForm()
+        setSuccessSignal((s) => s + 1)
+      }
     } catch (err) {
-      setError('Impossible d\'ajouter l\'entrée. Veuillez réessayer.')
+      setError(
+        editingId !== null
+          ? 'Impossible de modifier l\'entrée. Veuillez réessayer.'
+          : 'Impossible d\'ajouter l\'entrée. Veuillez réessayer.'
+      )
       console.error(err)
     } finally {
       setIsLoading(false)
     }
-  }, [newEntry, entries])
+  }, [newEntry, entries, editingId, resetForm])
+
+  const startEdit = useCallback((entry: FuelEntry) => {
+    setEditingId(entry.id)
+    setNewEntry({
+      date: entry.date,
+      kmCompteur: entry.kmCompteur > 0 ? entry.kmCompteur.toString() : '',
+      litres: entry.litres.toString(),
+      prixLitre: entry.prixLitre.toString(),
+      isFullTank: entry.isFullTank,
+    })
+    setKmCompteurError(null)
+    setError(null)
+    setActiveTab('dashboard')
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [])
+
+  const cancelEdit = useCallback(() => {
+    resetForm()
+  }, [resetForm])
 
   const deleteEntry = useCallback(async (id: number) => {
     setDeletingId(id)
@@ -296,6 +350,9 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
             onAddEntry={addEntry}
             isAuthenticated={isAuthenticated}
             kmCompteurError={kmCompteurError}
+            isEditing={editingId !== null}
+            onCancelEdit={cancelEdit}
+            successSignal={successSignal}
           />
         )}
 
@@ -303,6 +360,7 @@ export default function FuelConsumptionApp({ initialEntries }: Props) {
           <HistoryTab
             enrichedEntries={enrichedEntries}
             onDelete={deleteEntry}
+            onEdit={startEdit}
             deletingId={deletingId}
             hasEntries={entries.length > 0}
             isAuthenticated={isAuthenticated}

--- a/components/fuel/DashboardTab.tsx
+++ b/components/fuel/DashboardTab.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { Wallet, Droplets, Route, Car, Plus, Loader2 } from 'lucide-react'
+import React, { useState, useEffect } from 'react'
+import { Wallet, Droplets, Route, Car, Plus, Loader2, Pencil, X } from 'lucide-react'
 import { QuestionCard } from './QuestionCard'
 import { FormField } from './FormField'
 import { MiniStat } from './MiniStat'
@@ -21,6 +21,9 @@ interface DashboardTabProps {
     onAddEntry: () => void
     isAuthenticated: boolean
     kmCompteurError?: string | null
+    isEditing?: boolean
+    onCancelEdit?: () => void
+    successSignal?: number
 }
 
 export function DashboardTab({
@@ -39,28 +42,33 @@ export function DashboardTab({
     onAddEntry,
     isAuthenticated,
     kmCompteurError,
+    isEditing = false,
+    onCancelEdit,
+    successSignal = 0,
 }: DashboardTabProps) {
     // Récupérer les dernières valeurs pour les placeholders
     const lastEntry = entries.length > 0 ? entries[entries.length - 1] : null
 
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
-    const prevIsLoading = useRef(isLoading);
 
     useEffect(() => {
-        if (prevIsLoading.current && !isLoading) {
-            setSuccessMessage("Plein ajouté avec succès !");
-            setTimeout(() => setSuccessMessage(null), 3000);
-        }
-        prevIsLoading.current = isLoading;
-    }, [isLoading]);
+        // Ne s'affiche que lorsqu'une saisie a réellement été enregistrée
+        if (successSignal === 0) return;
+        setSuccessMessage("Saisie enregistrée avec succès !");
+        const timer = setTimeout(() => setSuccessMessage(null), 3000);
+        return () => clearTimeout(timer);
+    }, [successSignal]);
 
     return (
         <div className="space-y-6 animate-fade-in">
             {/* Add Entry Form - Moved to top */}
             <div className="card p-5">
                 <h2 className="text-lg font-bold text-gray-100 mb-4 flex items-center gap-2">
-                    <Plus className="w-5 h-5 text-indigo-600" />
-                    Ajouter un plein
+                    {isEditing ? (
+                        <><Pencil className="w-5 h-5 text-indigo-600" /> Modifier la saisie</>
+                    ) : (
+                        <><Plus className="w-5 h-5 text-indigo-600" /> Ajouter un plein</>
+                    )}
                 </h2>
 
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -121,19 +129,32 @@ export function DashboardTab({
                         Cochez cette case uniquement si vous avez fait le plein complet.
                     </p>
                 </div>
-                <button
-                    onClick={onAddEntry}
-                    disabled={isLoading || !isAuthenticated}
-                    className="btn-primary mt-4 w-full flex items-center justify-center gap-2"
-                >
-                    {isLoading ? (
-                        <><Loader2 className="w-5 h-5 animate-spin" /> Ajout en cours...</>
-                    ) : !isAuthenticated ? (
-                        <><Plus className="w-5 h-5" /> Connexion requise</>
-                    ) : (
-                        <><Plus className="w-5 h-5" /> Ajouter le plein</>
+                <div className="mt-4 flex gap-2">
+                    <button
+                        onClick={onAddEntry}
+                        disabled={isLoading || !isAuthenticated}
+                        className="btn-primary flex-1 flex items-center justify-center gap-2"
+                    >
+                        {isLoading ? (
+                            <><Loader2 className="w-5 h-5 animate-spin" /> {isEditing ? 'Modification...' : 'Ajout en cours...'}</>
+                        ) : !isAuthenticated ? (
+                            <><Plus className="w-5 h-5" /> Connexion requise</>
+                        ) : isEditing ? (
+                            <><Pencil className="w-5 h-5" /> Enregistrer les modifications</>
+                        ) : (
+                            <><Plus className="w-5 h-5" /> Ajouter le plein</>
+                        )}
+                    </button>
+                    {isEditing && (
+                        <button
+                            onClick={onCancelEdit}
+                            disabled={isLoading}
+                            className="btn-secondary flex items-center justify-center gap-2 px-4"
+                        >
+                            <X className="w-5 h-5" /> Annuler
+                        </button>
                     )}
-                </button>
+                </div>
                 {successMessage && (
                     <div className="mt-4 p-3 bg-green-800 text-green-200 rounded-lg">
                         {successMessage}
@@ -219,7 +240,7 @@ export function DashboardTab({
                 <MiniStat label="Coût/100km" value={`${stats.coutMoyenPer100km.toFixed(2)} €`} />
                 <MiniStat label="Prix moyen/L" value={`${stats.prixMoyenLitreRecent.toFixed(3)} €`} />
                 <MiniStat label="Total parcouru" value={`${stats.totalKm.toLocaleString('fr-FR')} km`} />
-                <MiniStat label="Nombre de pleins" value={`${Math.max(0, entries.length - 1)}`} />
+                <MiniStat label="Nombre de pleins" value={`${entries.length}`} />
             </div>
         </div>
     )

--- a/components/fuel/HistoryTab.tsx
+++ b/components/fuel/HistoryTab.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
-import { Calendar, Loader2, Trash2 } from 'lucide-react'
+import { Calendar, Loader2, Pencil, Trash2 } from 'lucide-react'
 import { formatDate } from '@/lib/utils/dateFormat'
 import { ConsumptionBadge } from './ConsumptionBadge'
 import { MobileEntryCard } from './MobileEntryCard'
 import { EmptyState } from './EmptyState'
-import { EnrichedFuelEntry } from '@/lib/types'
+import { EnrichedFuelEntry, FuelEntry } from '@/lib/types'
 
 interface HistoryTabProps {
     enrichedEntries: EnrichedFuelEntry[]
     onDelete: (id: number) => void
+    onEdit: (entry: FuelEntry) => void
     deletingId: number | null
     hasEntries: boolean
     isAuthenticated: boolean
 }
 
-export function HistoryTab({ enrichedEntries, onDelete, deletingId, hasEntries, isAuthenticated }: HistoryTabProps) {
+export function HistoryTab({ enrichedEntries, onDelete, onEdit, deletingId, hasEntries, isAuthenticated }: HistoryTabProps) {
     return (
         <div className="space-y-4 animate-fade-in">
             <h2 className="text-lg font-bold text-gray-100 flex items-center gap-2">
@@ -43,7 +44,7 @@ export function HistoryTab({ enrichedEntries, onDelete, deletingId, hasEntries, 
                             {[...enrichedEntries].reverse().map((entry) => (
                                 <tr key={entry.id} className="hover:bg-gray-700/50 transition-colors">
                                     <td className="table-cell">{formatDate(entry.date)}</td>
-                                    <td className="table-cell text-right">{entry.kmCompteur.toLocaleString('fr-FR')}</td>
+                                    <td className="table-cell text-right">{entry.kmCompteur > 0 ? entry.kmCompteur.toLocaleString('fr-FR') : '-'}</td>
                                     <td className="table-cell text-right font-medium">
                                         {entry.kmParcourus > 0 ? `${entry.kmParcourus} km` : '-'}
                                     </td>
@@ -67,19 +68,34 @@ export function HistoryTab({ enrichedEntries, onDelete, deletingId, hasEntries, 
                                         <ConsumptionBadge value={entry.consoL100km} />
                                     </td>
                                     <td className="table-cell text-center">
-                                        <button
-                                            onClick={() => onDelete(entry.id)}
-                                            disabled={deletingId === entry.id || !isAuthenticated}
-                                            className="btn-danger"
-                                        >
-                                            {deletingId === entry.id ? (
-                                                <Loader2 className="w-4 h-4 animate-spin" />
-                                            ) : !isAuthenticated ? (
-                                                <span className="text-gray-400">🔒</span>
-                                            ) : (
-                                                <Trash2 className="w-4 h-4" />
-                                            )}
-                                        </button>
+                                        <div className="flex items-center justify-center gap-1">
+                                            <button
+                                                onClick={() => onEdit(entry)}
+                                                disabled={!isAuthenticated}
+                                                className="text-indigo-400 hover:text-indigo-300 hover:bg-indigo-900/20 p-2 rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                                                title="Modifier"
+                                            >
+                                                {!isAuthenticated ? (
+                                                    <span className="text-gray-400">🔒</span>
+                                                ) : (
+                                                    <Pencil className="w-4 h-4" />
+                                                )}
+                                            </button>
+                                            <button
+                                                onClick={() => onDelete(entry.id)}
+                                                disabled={deletingId === entry.id || !isAuthenticated}
+                                                className="btn-danger"
+                                                title="Supprimer"
+                                            >
+                                                {deletingId === entry.id ? (
+                                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                                ) : !isAuthenticated ? (
+                                                    <span className="text-gray-400">🔒</span>
+                                                ) : (
+                                                    <Trash2 className="w-4 h-4" />
+                                                )}
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
                             ))}
@@ -95,6 +111,7 @@ export function HistoryTab({ enrichedEntries, onDelete, deletingId, hasEntries, 
                         key={entry.id}
                         entry={entry}
                         onDelete={onDelete}
+                        onEdit={onEdit}
                         isDeleting={deletingId === entry.id}
                         isAuthenticated={isAuthenticated}
                     />

--- a/components/fuel/MobileEntryCard.tsx
+++ b/components/fuel/MobileEntryCard.tsx
@@ -1,32 +1,28 @@
 import React from 'react'
-import { Loader2, Trash2 } from 'lucide-react'
+import { Loader2, Pencil, Trash2 } from 'lucide-react'
 import { formatDateLong } from '@/lib/utils/dateFormat'
 import { ConsumptionBadge } from './ConsumptionBadge'
+import { EnrichedFuelEntry, FuelEntry } from '@/lib/types'
 
 interface MobileEntryCardProps {
-    entry: {
-        id: number
-        date: string
-        kmCompteur: number
-        kmParcourus: number
-        litres: number
-        prixLitre: number
-        coutTotal: number
-        consoL100km: number
-        isFullTank: boolean
-    }
+    entry: EnrichedFuelEntry
     onDelete: (id: number) => void
+    onEdit: (entry: FuelEntry) => void
     isDeleting: boolean
     isAuthenticated: boolean
 }
 
-export function MobileEntryCard({ entry, onDelete, isDeleting, isAuthenticated }: MobileEntryCardProps) {
+export function MobileEntryCard({ entry, onDelete, onEdit, isDeleting, isAuthenticated }: MobileEntryCardProps) {
+    const hasKm = entry.kmCompteur > 0
+
     return (
         <div className="card p-4">
             <div className="flex justify-between items-start mb-3">
                 <div>
                     <p className="font-semibold text-gray-100">{formatDateLong(entry.date)}</p>
-                    <p className="text-sm text-gray-500">{entry.kmCompteur.toLocaleString('fr-FR')} km</p>
+                    {hasKm && (
+                        <p className="text-sm text-gray-500">{entry.kmCompteur.toLocaleString('fr-FR')} km</p>
+                    )}
                     {entry.isFullTank ? (
                         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-900/50 text-green-300 border border-green-700 mt-1">
                             Plein complet
@@ -37,31 +33,43 @@ export function MobileEntryCard({ entry, onDelete, isDeleting, isAuthenticated }
                         </span>
                     )}
                 </div>
-                <button onClick={() => onDelete(entry.id)} disabled={isDeleting || !isAuthenticated} className="btn-danger">
-                    {isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : !isAuthenticated ? <span className="text-gray-400">🔒</span> : <Trash2 className="w-4 h-4" />}
-                </button>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={() => onEdit(entry)}
+                        disabled={!isAuthenticated}
+                        className="text-indigo-400 hover:text-indigo-300 hover:bg-indigo-900/20 p-2 rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Modifier"
+                    >
+                        {!isAuthenticated ? <span className="text-gray-400">🔒</span> : <Pencil className="w-4 h-4" />}
+                    </button>
+                    <button onClick={() => onDelete(entry.id)} disabled={isDeleting || !isAuthenticated} className="btn-danger" title="Supprimer">
+                        {isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : !isAuthenticated ? <span className="text-gray-400">🔒</span> : <Trash2 className="w-4 h-4" />}
+                    </button>
+                </div>
             </div>
 
-            {entry.kmParcourus > 0 && (
-                <div className="grid grid-cols-2 gap-2 text-sm">
-                    <div className="bg-gray-50 rounded-lg p-3">
-                        <p className="text-gray-500 text-xs">Parcourus</p>
-                        <p className="font-semibold">{entry.kmParcourus} km</p>
-                    </div>
-                    <div className="bg-gray-50 rounded-lg p-3">
-                        <p className="text-gray-500 text-xs">Litres</p>
-                        <p className="font-semibold">{entry.litres.toFixed(2)} L à {entry.prixLitre.toFixed(2)} €</p>
-                    </div>
-                    <div className="bg-gray-50 rounded-lg p-3">
-                        <p className="text-gray-500 text-xs">Coût</p>
-                        <p className="font-semibold">{entry.coutTotal.toFixed(2)} €</p>
-                    </div>
-                    <div className="bg-gray-50 rounded-lg p-3">
-                        <p className="text-gray-500 text-xs">Conso L/100km</p>
-                        <ConsumptionBadge value={entry.consoL100km} />
-                    </div>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+                <div className="bg-gray-700/50 rounded-lg p-3">
+                    <p className="text-gray-400 text-xs">Litres</p>
+                    <p className="font-semibold text-gray-100">{entry.litres.toFixed(2)} L à {entry.prixLitre.toFixed(3)} €</p>
                 </div>
-            )}
+                <div className="bg-gray-700/50 rounded-lg p-3">
+                    <p className="text-gray-400 text-xs">Coût</p>
+                    <p className="font-semibold text-gray-100">{entry.coutTotal.toFixed(2)} €</p>
+                </div>
+                {entry.kmParcourus > 0 && (
+                    <>
+                        <div className="bg-gray-700/50 rounded-lg p-3">
+                            <p className="text-gray-400 text-xs">Parcourus</p>
+                            <p className="font-semibold text-gray-100">{entry.kmParcourus} km</p>
+                        </div>
+                        <div className="bg-gray-700/50 rounded-lg p-3">
+                            <p className="text-gray-400 text-xs">Conso L/100km</p>
+                            <ConsumptionBadge value={entry.consoL100km} />
+                        </div>
+                    </>
+                )}
+            </div>
         </div>
     )
 }

--- a/lib/calculations.ts
+++ b/lib/calculations.ts
@@ -165,6 +165,43 @@ export function calculateMonthlyStats(enrichedEntries: EnrichedFuelEntry[]): Mon
     .sort((a, b) => a.mois.localeCompare(b.mois))
 }
 
+/**
+ * Valide un kilométrage en fonction de la date de la saisie.
+ * Le compteur doit être croissant dans le temps : supérieur à toute saisie
+ * antérieure et inférieur à toute saisie postérieure.
+ * Retourne un message d'erreur, ou null si le kilométrage est valide.
+ */
+export function validateKmCompteur(
+  entries: FuelEntry[],
+  dateStr: string,
+  km: number,
+  excludeId?: number
+): string | null {
+  const date = new Date(dateStr).getTime()
+  const relevant = entries.filter(
+    (e) => e.kmCompteur > 0 && e.id !== excludeId
+  )
+
+  const before = relevant.filter((e) => new Date(e.date).getTime() < date)
+  const after = relevant.filter((e) => new Date(e.date).getTime() > date)
+
+  const maxBefore = before.length > 0
+    ? Math.max(...before.map((e) => e.kmCompteur))
+    : null
+  const minAfter = after.length > 0
+    ? Math.min(...after.map((e) => e.kmCompteur))
+    : null
+
+  if (maxBefore !== null && km <= maxBefore) {
+    return `Le kilométrage doit être supérieur à ${maxBefore.toLocaleString('fr-FR')} km (relevé d'une date antérieure)`
+  }
+  if (minAfter !== null && km >= minAfter) {
+    return `Le kilométrage doit être inférieur à ${minAfter.toLocaleString('fr-FR')} km (relevé d'une date postérieure)`
+  }
+
+  return null
+}
+
 export function estimateTrip(distance: number, consoMoyenne: number, prixLitre: number): TripEstimate {
   const litresEstimes = (distance * consoMoyenne) / 100
   const coutEstime = litresEstimes * prixLitre


### PR DESCRIPTION
- Modifier une saisie existante (bouton crayon dans l'historique,
  formulaire passant en mode édition + endpoint PUT /api/entries)
- Validation du kilométrage en fonction de la date : doit être
  supérieur aux relevés antérieurs et inférieur aux relevés postérieurs
- Historique mobile : Litres et Coût toujours affichés, même sans
  kilométrage (couleurs adaptées au thème sombre)
- Compteur affiché en '-' quand absent (table desktop)
- Correctifs : message de succès uniquement en cas de réussite réelle,
  'Nombre de pleins' affiche le compte exact